### PR TITLE
Add dark theme template

### DIFF
--- a/app/assets/css/dark-theme.css
+++ b/app/assets/css/dark-theme.css
@@ -58,3 +58,4 @@ div.viewport-container-landscape {
   & span[style*="color: rgb(71, 85, 105)"] {
     color: #dfafdf !important;
   }
+}

--- a/app/assets/css/dark-theme.css
+++ b/app/assets/css/dark-theme.css
@@ -1,0 +1,60 @@
+body {
+  background-color: #0f0e0f !important;
+}
+div.viewport-container,
+div.viewport-container-landscape {
+  & .game-setup-screen,
+  & .game-setup-screen-landscape {
+    background-color: black;
+  }
+  & div:has(>input),
+  & .settings-field div:nth-child(2) .box-border {
+    background-color: #0f0f0f !important;
+  }
+  &,
+  & .game-screen,
+  & .game-screen-landscape,
+  & .modal-content,
+  & .settings-buttons-container {
+    background-color: #1f1f1f;
+  }
+  @layer utilities {
+      & .shadow-\[0_2px_0_0_\#cbd5e1\] {
+        --tw-shadow: 0 2px 0 0 var(--tw-shadow-color,#3f4246);
+      }
+    &  .text-\[\#1088C9\] {
+        color: #3fbfff;
+      }
+    & .text-\[\#FF5555\] {
+        color: #ff9191;
+    }
+  }
+  & img.logo {
+    filter: brightness(1.35);
+  }
+  & h1 {
+    color: #cfdfef !important;
+  }
+  & p,
+  & [class *= "-label"],
+  & .text-sm {
+    color: #afbfcf !important;
+  }
+  & button:not(.bg-\[\#FF7900\]):not(.bg-\[\#1088C9\]),
+  & .flex .box-border:has(>span) {
+    & svg,
+    & svg path {
+      stroke: #dfdfdf !important;
+    }
+    background-color: #3f3f3f !important;
+    border-color: #40454a !important;
+    color: #dfdfdf !important;
+  }
+  & .landscape-navigation,
+  & .ml-auto {
+    background-color: #363735 !important;
+  }
+  /* try to implement this logic side */
+  & span[style*="color: rgb(71, 85, 105)"] {
+    color: #dfafdf !important;
+  }


### PR DESCRIPTION
There is a stylesheet that is used to activate a "dark mode" to a separate instance of the domain (beyscore.worldbeyblade.org/dt).
It is expected to work in a unique instance to assure that the themes are default on loading webapp without needing to worry about cookies or local storage.

Practical functionality of this sheet is to be implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced a comprehensive dark theme with darker backgrounds and refined color palettes across app screens, game interfaces, settings, and modals.
  * Improved text-to-background contrast and visual consistency with updated heading, paragraph, label, and small-text colors.
  * Added utility styles for shadows, color tweaks, image brightness, and button/box-border appearance; adjusted specific text tones for improved legibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->